### PR TITLE
correct invalid usage of @CacheConfig annotation

### DIFF
--- a/framework-docs/modules/ROOT/pages/integration/cache/annotations.adoc
+++ b/framework-docs/modules/ROOT/pages/integration/cache/annotations.adoc
@@ -485,7 +485,7 @@ comes into play. The following examples uses `@CacheConfig` to set the name of t
 
 [source,java,indent=0,subs="verbatim,quotes"]
 ----
-	@CacheConfig("books") <1>
+	@CacheConfig(cacheNames = "books") <1>
 	public class BookRepositoryImpl implements BookRepository {
 
 		@Cacheable


### PR DESCRIPTION
Original example used `@CacheConfig("books")`, which leads to a runtime error because the annotation requires cacheNames to be explicitly defined.
This PR updates the annotation to `@CacheConfig(cacheNames = "books")` for correctness.